### PR TITLE
Fix `:path` -> `:patch` typo

### DIFF
--- a/src/com/grzm/awyeah/http_client.clj
+++ b/src/com/grzm/awyeah/http_client.clj
@@ -64,7 +64,7 @@
    :put "PUT"
    :head "HEAD"
    :delete "DELETE"
-   :path "PATCH"})
+   :patch "PATCH"})
 
 (defn byte-buffer->byte-array
   [^ByteBuffer bbuf]


### PR DESCRIPTION
This allows AWS API requests that actually use `PATCH` requests to work.
